### PR TITLE
PolyChord & MultiNest fixes, improvements

### DIFF
--- a/montepython/MultiNest.py
+++ b/montepython/MultiNest.py
@@ -132,6 +132,8 @@ def initialise(cosmo, data, command_line):
     # Use chain name as a base name for MultiNest files
     chain_name = [a for a in command_line.folder.split(os.path.sep) if a][-1]
     base_name = os.path.join(NS_folder, chain_name)
+    #FK: add base_name to NS_arguments for later reference
+    data.NS_arguments['base_dir'] = base_name
 
     # Prepare arguments for PyMultiNest
     # -- Automatic arguments
@@ -277,11 +279,17 @@ def run(cosmo, data, command_line):
     # Assuming this worked, i.e. if output is `None`,
     # state it and suggest the user to analyse the output.
     if output is None:
-        warnings.warn('The sampling with MultiNest is done.\n' +
-                      'You can now analyse the output calling Monte Python ' +
-                      ' with the -info flag in the chain_name/NS subfolder,' +
-                      'or, if you used multimodal sampling, in the ' +
-                      'chain_name/mode_# subfolders.')
+        # FK: write out the warning message below also as a file in the NS-subfolder
+        # so that there's a clear indication for convergence instead of just looking at
+        # the STDOUT-log!
+        text = 'The sampling with MultiNest is done.\n' + \
+               'You can now analyse the output calling Monte Python ' + \
+               'with the -info flag in the chain_name/NS subfolder,' + \
+               'or, if you used multimodal sampling, in the ' + \
+               'chain_name/mode_# subfolders.'
+        fname = os.path.join(data.NS_arguments['base_dir'], 'convergence.txt')
+        with open(fname, 'w') as afile:
+            afile.write(text)
 
 
 def from_NS_output_to_chains(folder):

--- a/montepython/MultiNest.py
+++ b/montepython/MultiNest.py
@@ -132,8 +132,8 @@ def initialise(cosmo, data, command_line):
     # Use chain name as a base name for MultiNest files
     chain_name = [a for a in command_line.folder.split(os.path.sep) if a][-1]
     base_name = os.path.join(NS_folder, chain_name)
-    #FK: add base_name to NS_arguments for later reference
-    data.NS_arguments['base_dir'] = base_name
+    #FK: add base folder name to NS_arguments for later reference
+    data.NS_arguments['base_dir'] = NS_folder
 
     # Prepare arguments for PyMultiNest
     # -- Automatic arguments
@@ -272,6 +272,11 @@ def run(cosmo, data, command_line):
         for i, name in enumerate(derived_param_names):
             cube[ndim+i] = data.mcmc_parameters[name]['current']
         return lkl
+    
+    #FK: recover name of base folder and remove entry from dict before passing it
+    # on to MN:
+    base_dir = data.NS_arguments['base_dir']
+    del data.NS_arguments['base_dir']
 
     # Launch MultiNest, and recover the output code
     output = nested_run(loglike, prior, **data.NS_arguments)
@@ -285,9 +290,9 @@ def run(cosmo, data, command_line):
         text = 'The sampling with MultiNest is done.\n' + \
                'You can now analyse the output calling Monte Python ' + \
                'with the -info flag in the chain_name/NS subfolder,' + \
-               'or, if you used multimodal sampling, in the ' + \
+               ' or, if you used multimodal sampling, in the ' + \
                'chain_name/mode_# subfolders.'
-        fname = os.path.join(data.NS_arguments['base_dir'], 'convergence.txt')
+        fname = os.path.join(base_dir, 'convergence.txt')
         with open(fname, 'w') as afile:
             afile.write(text)
 

--- a/montepython/PolyChord.py
+++ b/montepython/PolyChord.py
@@ -357,7 +357,9 @@ def run(cosmo, data, command_line):
         data.update_cosmo_arguments()
 
         # Compute likelihood
-        logl = sampler.compute_lkl(cosmo, data)[0,0]
+        #logl = sampler.compute_lkl(cosmo, data)[0,0]
+        # FK: index to scalar variable error...
+        logl = sampler.compute_lkl(cosmo, data)
 
         # Compute derived parameters and pass them back
         phi = [0.0] * nDerived

--- a/montepython/PolyChord.py
+++ b/montepython/PolyChord.py
@@ -233,7 +233,7 @@ def initialise(cosmo, data, command_line):
         os.makedirs(PC_folder)
 
     # If absent, create the sub-folder PC/clusters
-    PC_clusters_folder = os.path.join(PC_folder,'clusters') 
+    PC_clusters_folder = os.path.join(PC_folder,'clusters')
     if not os.path.exists(PC_clusters_folder):
         os.makedirs(PC_clusters_folder)
 
@@ -376,9 +376,18 @@ def run(cosmo, data, command_line):
     # Launch PolyChord
     polychord_run(loglike, nDims, nDerived, settings, prior)
 
-    warnings.warn('The sampling with PolyChord is done.\n' +
-                  'You can now analyse the output calling Monte Python ' +
-                  ' with the -info flag in the chain_name/PC subfolder,')
+    # FK: write out the warning message below also as a file in the PC-subfolder
+    # so that there's a clear indication for convergence instead of just looking at
+    # the STDOUT-log!
+    text = 'The sampling with PolyChord is done.\n' + \
+           'You can now analyse the output calling Monte Python ' + \
+           'with the -info flag in the chain_name/PC subfolder.'
+
+    warnings.warn(text)
+
+    fname = os.path.join(data.PC_arguments['base_dir'], 'convergence.txt')
+    with open(fname, 'w') as afile:
+        afile.write(text)
 
 def from_PC_output_to_chains(folder):
     """
@@ -435,10 +444,10 @@ def from_PC_output_to_chains(folder):
             if line.strip()[0] == '#':
                 continue
 
-            # These lines allow PolyChord to deal with fixed nuisance parameters 
+            # These lines allow PolyChord to deal with fixed nuisance parameters
             sigma = float(line.split(',')[3].strip())
             if sigma == 0.0:
-                #If derived parameter, keep it, else discard it:                                 
+                #If derived parameter, keep it, else discard it:
                 paramtype = line.split(',')[5].strip()[1:-2]
                 if paramtype != 'derived':
                     continue


### PR DESCRIPTION
Hi Thejs,

I've pushed the following bugfix for `PolyChord.py`: 

1) in line 360 the '[0,0]' reference caused a "index to scalar variable" error. So I commented it out.

Moreover, the PR also contains the following improvement/additions to `PolyChord.py` and `MultiNest.py`:
I've added an explicit write-out of a `convergence.txt` file to the base `NS` or `PC` subfolder of the run which contains the same message that is also sent to STDOUT after the run has finished. 
The reasoning being that I had some mishaps on a cluster with queuing system that somehow resulted in sending my STDOUT-log-files to Nirvana... Once that happens it's tough to see if the run has really converged or just segfaulted in between... Hence, I thought such a status file might be quite convenient.

Cheers,

Fabian 