### PR TITLE
Updated PolyChord & MultiNest fixes and improvements

### DIFF
--- a/montepython/MultiNest.py
+++ b/montepython/MultiNest.py
@@ -132,6 +132,8 @@ def initialise(cosmo, data, command_line):
     # Use chain name as a base name for MultiNest files
     chain_name = [a for a in command_line.folder.split(os.path.sep) if a][-1]
     base_name = os.path.join(NS_folder, chain_name)
+    #FK: add base_name to NS_arguments for later reference
+    data.NS_arguments['base_dir'] = base_name
 
     # Prepare arguments for PyMultiNest
     # -- Automatic arguments
@@ -277,11 +279,17 @@ def run(cosmo, data, command_line):
     # Assuming this worked, i.e. if output is `None`,
     # state it and suggest the user to analyse the output.
     if output is None:
-        warnings.warn('The sampling with MultiNest is done.\n' +
-                      'You can now analyse the output calling Monte Python ' +
-                      ' with the -info flag in the chain_name/NS subfolder,' +
-                      'or, if you used multimodal sampling, in the ' +
-                      'chain_name/mode_# subfolders.')
+        # FK: write out the warning message below also as a file in the NS-subfolder
+        # so that there's a clear indication for convergence instead of just looking at
+        # the STDOUT-log!
+        text = 'The sampling with MultiNest is done.\n' + \
+               'You can now analyse the output calling Monte Python ' + \
+               'with the -info flag in the chain_name/NS subfolder,' + \
+               'or, if you used multimodal sampling, in the ' + \
+               'chain_name/mode_# subfolders.'
+        fname = os.path.join(data.NS_arguments['base_dir'], 'convergence.txt')
+        with open(fname, 'w') as afile:
+            afile.write(text)
 
 
 def from_NS_output_to_chains(folder):

--- a/montepython/MultiNest.py
+++ b/montepython/MultiNest.py
@@ -132,8 +132,8 @@ def initialise(cosmo, data, command_line):
     # Use chain name as a base name for MultiNest files
     chain_name = [a for a in command_line.folder.split(os.path.sep) if a][-1]
     base_name = os.path.join(NS_folder, chain_name)
-    #FK: add base_name to NS_arguments for later reference
-    data.NS_arguments['base_dir'] = base_name
+    #FK: add base folder name to NS_arguments for later reference
+    data.NS_arguments['base_dir'] = NS_folder
 
     # Prepare arguments for PyMultiNest
     # -- Automatic arguments
@@ -272,6 +272,11 @@ def run(cosmo, data, command_line):
         for i, name in enumerate(derived_param_names):
             cube[ndim+i] = data.mcmc_parameters[name]['current']
         return lkl
+    
+    #FK: recover name of base folder and remove entry from dict before passing it
+    # on to MN:
+    base_dir = data.NS_arguments['base_dir']
+    del data.NS_arguments['base_dir']
 
     # Launch MultiNest, and recover the output code
     output = nested_run(loglike, prior, **data.NS_arguments)
@@ -285,9 +290,9 @@ def run(cosmo, data, command_line):
         text = 'The sampling with MultiNest is done.\n' + \
                'You can now analyse the output calling Monte Python ' + \
                'with the -info flag in the chain_name/NS subfolder,' + \
-               'or, if you used multimodal sampling, in the ' + \
+               ' or, if you used multimodal sampling, in the ' + \
                'chain_name/mode_# subfolders.'
-        fname = os.path.join(data.NS_arguments['base_dir'], 'convergence.txt')
+        fname = os.path.join(base_dir, 'convergence.txt')
         with open(fname, 'w') as afile:
             afile.write(text)
 

--- a/montepython/PolyChord.py
+++ b/montepython/PolyChord.py
@@ -357,7 +357,9 @@ def run(cosmo, data, command_line):
         data.update_cosmo_arguments()
 
         # Compute likelihood
-        logl = sampler.compute_lkl(cosmo, data)[0,0]
+        #logl = sampler.compute_lkl(cosmo, data)[0,0]
+        # FK: index to scalar variable error...
+        logl = sampler.compute_lkl(cosmo, data)
 
         # Compute derived parameters and pass them back
         phi = [0.0] * nDerived

--- a/montepython/PolyChord.py
+++ b/montepython/PolyChord.py
@@ -233,7 +233,7 @@ def initialise(cosmo, data, command_line):
         os.makedirs(PC_folder)
 
     # If absent, create the sub-folder PC/clusters
-    PC_clusters_folder = os.path.join(PC_folder,'clusters') 
+    PC_clusters_folder = os.path.join(PC_folder,'clusters')
     if not os.path.exists(PC_clusters_folder):
         os.makedirs(PC_clusters_folder)
 
@@ -376,9 +376,18 @@ def run(cosmo, data, command_line):
     # Launch PolyChord
     polychord_run(loglike, nDims, nDerived, settings, prior)
 
-    warnings.warn('The sampling with PolyChord is done.\n' +
-                  'You can now analyse the output calling Monte Python ' +
-                  ' with the -info flag in the chain_name/PC subfolder,')
+    # FK: write out the warning message below also as a file in the PC-subfolder
+    # so that there's a clear indication for convergence instead of just looking at
+    # the STDOUT-log!
+    text = 'The sampling with PolyChord is done.\n' + \
+           'You can now analyse the output calling Monte Python ' + \
+           'with the -info flag in the chain_name/PC subfolder.'
+
+    warnings.warn(text)
+
+    fname = os.path.join(data.PC_arguments['base_dir'], 'convergence.txt')
+    with open(fname, 'w') as afile:
+        afile.write(text)
 
 def from_PC_output_to_chains(folder):
     """
@@ -435,10 +444,10 @@ def from_PC_output_to_chains(folder):
             if line.strip()[0] == '#':
                 continue
 
-            # These lines allow PolyChord to deal with fixed nuisance parameters 
+            # These lines allow PolyChord to deal with fixed nuisance parameters
             sigma = float(line.split(',')[3].strip())
             if sigma == 0.0:
-                #If derived parameter, keep it, else discard it:                                 
+                #If derived parameter, keep it, else discard it:
                 paramtype = line.split(',')[5].strip()[1:-2]
                 if paramtype != 'derived':
                     continue

--- a/montepython/mcmc.py
+++ b/montepython/mcmc.py
@@ -292,10 +292,26 @@ def chain(cosmo, data, command_line):
         # if we want to compute the starting point by minimising lnL (instead of taking it from input file or bestfit file)
         minimum = 0
         if command_line.minimize:
-            minimum = sampler.get_minimum(cosmo, data, command_line, C)
+            minimum, min_chi2 = sampler.get_minimum(cosmo, data, command_line, C)
+
             parameter_names = data.get_mcmc_parameters(['last_accepted'])
             for index,elem in parameter_names:
                 data.mcmc_parameters[elem]['last_accepted'] = minimum[index]
+
+            #FK: write out the results of the minimzer:
+            labels = data.get_mcmc_parameters(['varying'])
+            fname = os.path.join(command_line.folder, 'results.minimized')
+            with open(fname, 'w') as f:
+                f.write('# minimized \chi^2 = {:} \n'.format(min_chi2))
+                f.write('# %s\n' % ', '.join(['%16s' % label for label in labels]))
+                for idx in xrange(len(labels)):
+                    bf_value = minimum[idx]
+                    if bf_value > 0:
+                        f.write(' %.6e\t' % bf_value)
+                    else:
+                        f.write('%.6e\t' % bf_value)
+                f.write('\n')
+            print 'Results of minimizer saved to: \n', fname
 
         # if we want to compute Fisher matrix and then stop
         if command_line.fisher:

--- a/montepython/sampler.py
+++ b/montepython/sampler.py
@@ -607,6 +607,14 @@ def get_fisher_matrix(cosmo, data, command_line, inv_fisher_matrix, minimum=0):
                 inv_fisher_matrix, parameter_names,
                 os.path.join(command_line.folder, 'inv_fisher.mat'))
 
+            # FK: also write-out gradient:
+            fname = os.path.join(command_line.folder, 'fisher_gradient.vec')
+            header = ''
+            for param in parameter_names:
+                header += '{:}, '.format(param)
+            header = header[:-2]
+            np.savetxt(fname, gradient, header=header)
+
     return inv_fisher_matrix
 
 

--- a/montepython/sampler.py
+++ b/montepython/sampler.py
@@ -375,7 +375,8 @@ def get_minimum(cosmo, data, command_line, covmat):
                  {'type': 'ineq', 'fun': lambda x: bounds[index,1] - x[index]},)
         print 'bounds on ',elem,' : ',bounds[index,0],bounds[index,1]
 
-    print 'parameters: ',parameters
+    #FK: use list-comprehension so that the parameter values are distinguishable from step to step
+    print 'parameters: ',[param for param in parameters]
     print 'stepsizes: ',stepsizes[0]
     print 'bounds: ',bounds
 
@@ -438,7 +439,8 @@ def get_minimum(cosmo, data, command_line, covmat):
     for index,elem in enumerate(parameter_names):
         print elem, 'new:', result.x[index], ', old:', parameters[index]
 
-    return result.x
+    #FK: return also min chi^2:
+    return result.x, result.fun
 
 def chi2_eff(params, cosmo, data, bounds=False):
     parameter_names = data.get_mcmc_parameters(['varying'])
@@ -454,7 +456,8 @@ def chi2_eff(params, cosmo, data, bounds=False):
     data.update_cosmo_arguments()
     # Compute loglike value for the new parameters
     chi2 = -2.*compute_lkl(cosmo, data)
-    print 'In minimization: ',chi2,' at ',params
+    #FK: use list-comprehension so that the parameter values are distinguishable from step to step
+    print 'In minimization: ',chi2,' at ',[param for param in params]
     return chi2
 
 def gradient_chi2_eff(params, cosmo, data, bounds=False):


### PR DESCRIPTION
Hi Thejs,

As written in PR #54 there was still a bug in the write-out of the `convergence.txt` for the MultiNest sampler. This has been fixed now.
Below you find the original description of PR #54:

I've pushed the following bugfix for PolyChord.py:

in line 360 the '[0,0]' reference caused a "index to scalar variable" error. So I commented it out.
Moreover, the PR also contains the following improvement/additions to PolyChord.py and MultiNest.py:
I've added an explicit write-out of a convergence.txt file to the base NS or PC subfolder of the run which contains the same message that is also sent to STDOUT after the run has finished.
The reasoning being that I had some mishaps on a cluster with queuing system that somehow resulted in sending my STDOUT-log-files to Nirvana... Once that happens it's tough to see if the run has really converged or just segfaulted in between... Hence, I thought such a status file might be quite convenient.

Cheers,

Fabian