### PR TITLE
Python 3 compatibility changes, TeX formatting fix

### DIFF
--- a/montepython/io_mp.py
+++ b/montepython/io_mp.py
@@ -351,7 +351,7 @@ def get_tex_name(name, number=1):
     for elem in tex_greek:
         if elem in name:
             position = name.find(elem)
-            name = name[:position]+"""\\"""+name[position:]
+            name = name[:position]+"""\\"""+name[position:position+len(elem)]+"{}"+name[position+len(elem):]
     if name.find('_') != -1:
         temp_name = name.split('_')[0]+'_{'
         for i in range(1, len(name.split('_'))):
@@ -480,7 +480,7 @@ class File(io.FileIO):
             byte_block = min(1024, bytes_in_file-total_bytes_scanned)
             self.seek(-(byte_block+total_bytes_scanned), 2)
             total_bytes_scanned += byte_block
-            lines_found += self.read(1024).count('\n')
+            lines_found += self.read(1024).decode(encoding='utf-8').count('\n')
         self.seek(-total_bytes_scanned, 2)
         line_list = list(self.readlines())
         return line_list[-lines_2find:]

--- a/montepython/sampler.py
+++ b/montepython/sampler.py
@@ -103,7 +103,7 @@ def read_args_from_chain(data, chain):
     success = 0
     # Test if last chain entry contains a step or a commented line
     while not success:
-        if chain_file.tail(1)[0].split('\t')[0] == '#':
+        if chain_file.tail(1)[0].decode(encoding='utf-8').split('\t')[0] == '#':
             commented_line += 1
         else:
             success += 1
@@ -115,7 +115,7 @@ def read_args_from_chain(data, chain):
         #data.mcmc_parameters[elem]['last_accepted'] = float(
         #    chain_file.tail(1)[0].split('\t')[i])
         data.mcmc_parameters[elem]['last_accepted'] = float(
-            chain_file.tail(commented_line+1)[commented_line].split('\t')[i])
+            chain_file.tail(commented_line+1)[commented_line].decode(encoding='utf-8').split('\t')[i])
         i += 1
 
 
@@ -150,13 +150,13 @@ def read_args_from_bestfit(data, bestfit):
             data.mcmc_parameters[elem]['last_accepted'] = \
                 bestfit_values[bestfit_names.index(elem)] / \
                 data.mcmc_parameters[elem]['scale']
-            sys.stdout.write('from best-fit file : ', elem, ' = ')
+            print('from best-fit file : ', elem, ' = ')
             print(bestfit_values[bestfit_names.index(elem)] / \
                 data.mcmc_parameters[elem]['scale'])
         else:
             data.mcmc_parameters[elem]['last_accepted'] = \
                 data.mcmc_parameters[elem]['initial'][0]
-            sys.stdout.write('from input file    : ', elem, ' = ')
+            print('from input file    : ', elem, ' = ')
             print(data.mcmc_parameters[elem]['initial'][0])
 
 
@@ -339,7 +339,7 @@ def get_covariance_matrix(cosmo, data, command_line):
 
     # Final print out, the actually used covariance matrix
     if not command_line.silent and not command_line.quiet:
-        sys.stdout.write('\nDeduced starting covariance matrix:\n')
+        print('\nDeduced starting covariance matrix:\n')
         print(parameter_names)
         print(matrix)
 


### PR DESCRIPTION
This pull request proposes minor fixes in MontePython code and the BK14 likelihood code, mostly to do with Python 3.x compatibility. 
The Python compatibility fixes include:
- `/` -> `//` for integer division (floor division)
- `sys.stdout.write()` -> `print()`
- `reduce` -> `functools.reduce`, this function has been moved to the `functools` module for backwards compatibility
- `pandas.DataFrame.as_matrix`-> `pandas.DataFrame.values`, this should be backwards compatible with older versions of `pandas`
- Python 2.x's `file.read()` always returns a string, but Python 3.x's equivalent method returns a `bytes` object when in binary mode. The fixes relate to converting the `bytes` to `str`.

An additional fix is related to a typo in `io_mp.get_tex_name()`, which results in the TeX name `$BB\alphadust$`, causing an undefined control sequence error. This has been corrected to generate `$BB\alpha{}dust$`.

Please check if you agree with the changes and thank you for developing and maintaining this package! 