### PR TITLE
Update cfitisio download link

### DIFF
--- a/wrapper_wmap/waf_tools/cfitsio.py
+++ b/wrapper_wmap/waf_tools/cfitsio.py
@@ -14,7 +14,7 @@ def configure(ctx):
   ctx.env.th = False
 
 def install_cfitsio(ctx):
-  atl.installsmthg_pre(ctx,"ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3280.tar.gz","cfitsio3280.tar.gz")
+  atl.installsmthg_pre(ctx,"https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3280.tar.gz","cfitsio3280.tar.gz")
   CCMACRO = "\"%s %s\""%(ctx.env.CC[0],ctx.env.mopt)
   CCMACRO = "CC=%s CXX=%s "%(CCMACRO,CCMACRO)
   CPPMACRO = "CPP=\"%s -E\" CXXCPP=\"g++ -E\" "%(ctx.env.CC[0])

--- a/wrapper_wmap_v4p1/waf_tools/cfitsio.py
+++ b/wrapper_wmap_v4p1/waf_tools/cfitsio.py
@@ -14,7 +14,7 @@ def configure(ctx):
   ctx.env.th = False
 
 def install_cfitsio(ctx):
-  atl.installsmthg_pre(ctx,"ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3280.tar.gz","cfitsio3280.tar.gz")
+  atl.installsmthg_pre(ctx,"https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3280.tar.gz","cfitsio3280.tar.gz")
   CCMACRO = "\"%s %s\""%(ctx.env.CC[0],ctx.env.mopt)
   CCMACRO = "CC=%s CXX=%s "%(CCMACRO,CCMACRO)
   CPPMACRO = "CPP=\"%s -E\" CXXCPP=\"g++ -E\" "%(ctx.env.CC[0])


### PR DESCRIPTION
Hello!

I'm trying to install the WMAP wrapper, and when running `./waf configure --install_all_deps`, pups up the following error message:

```
Checking for library ['cfitsio']                                           : not found
cfitsio not found
check that cfitsio_prefix or cfitsio_lib and cfitsio_include command line options point toward your cfitsio install
or check that cfitsio is compiled in 64 bit
cfitsio not found, try to install it
Install 'cfitsio3280.tar.gz'
download from ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3280.tar.gz
curl ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3280.tar.gz build/cfitsio3280.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (67) Access denied: 550
```

Looking in the web, I found that this link actually works and corresponds to the same cfitsio version: [https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3280.tar.gz](https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3280.tar.gz)